### PR TITLE
Refactor: poll long-running operations for GCP Function deployment

### DIFF
--- a/lithops/constants.py
+++ b/lithops/constants.py
@@ -111,7 +111,8 @@ SERVERLESS_BACKENDS = [
     'aliyun_fc',
     'oracle_f',
     'k8s',
-    'singularity'
+    'singularity',
+    'iluvatar',
 ]
 
 STANDALONE_BACKENDS = [

--- a/lithops/constants.py
+++ b/lithops/constants.py
@@ -111,8 +111,7 @@ SERVERLESS_BACKENDS = [
     'aliyun_fc',
     'oracle_f',
     'k8s',
-    'singularity',
-    'iluvatar',
+    'singularity'
 ]
 
 STANDALONE_BACKENDS = [


### PR DESCRIPTION
Instead of polling the function resource (which can return 404), update the deployment logic
to poll the long-running operation returned by the create() method

More information about operation polling for gcp [here](https://cloud.google.com/resource-manager/reference/rest/v1/operations/get)
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

